### PR TITLE
feat: implement CommentLike and Reply repositories with PostgreSQL support

### DIFF
--- a/migrations/1751220421470_create-table-comment-likes.js
+++ b/migrations/1751220421470_create-table-comment-likes.js
@@ -1,0 +1,37 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.createTable("comment_likes", {
+    id: {
+      type: "VARCHAR(50)",
+      primaryKey: true,
+    },
+    comment_id: {
+      type: "VARCHAR(50)",
+      notNull: true,
+      references: "comments(id)",
+      onDelete: "cascade",
+    },
+    owner: {
+      type: "VARCHAR(50)",
+      notNull: true,
+      references: "users(id)",
+      onDelete: "cascade",
+    },
+    date: {
+      type: "TIMESTAMP",
+      notNull: true,
+    },
+  });
+
+  // Create unique constraint to prevent duplicate likes
+  pgm.addConstraint("comment_likes", "unique_comment_like", {
+    unique: ["comment_id", "owner"],
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable("comment_likes");
+};

--- a/migrations/1751220521470_create-table-replies.js
+++ b/migrations/1751220521470_create-table-replies.js
@@ -1,0 +1,37 @@
+exports.up = (pgm) => {
+  pgm.createTable('replies', {
+    id: {
+      type: 'VARCHAR(50)',
+      primaryKey: true,
+    },
+    content: {
+      type: 'TEXT',
+      notNull: true,
+    },
+    date: {
+      type: 'TEXT',
+      notNull: true,
+    },
+    owner: {
+      type: 'VARCHAR(50)',
+      notNull: true,
+      references: 'users(id)',
+      onDelete: 'CASCADE',
+    },
+    comment_id: {
+      type: 'VARCHAR(50)',
+      notNull: true,
+      references: 'comments(id)',
+      onDelete: 'CASCADE',
+    },
+    is_delete: {
+      type: 'BOOLEAN',
+      notNull: true,
+      default: false,
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('replies');
+};

--- a/src/Applications/use_case/AddReplyUseCase.js
+++ b/src/Applications/use_case/AddReplyUseCase.js
@@ -1,0 +1,18 @@
+const NewReply = require('../../Domains/replies/entities/NewReply');
+
+class AddReplyUseCase {
+  constructor({ commentRepository, threadRepository, replyRepository }) {
+    this._commentRepository = commentRepository;
+    this._threadRepository = threadRepository;
+    this._replyRepository = replyRepository;
+  }
+
+  async execute(useCasePayload, commentId, threadId, owner) {
+    const newReply = new NewReply(useCasePayload);
+    await this._threadRepository.verifyThreadExists(threadId);
+    await this._commentRepository.verifyCommentExists(commentId);
+    return this._replyRepository.addReply(newReply, commentId, owner);
+  }
+}
+
+module.exports = AddReplyUseCase;

--- a/src/Applications/use_case/DeleteReplyUseCase.js
+++ b/src/Applications/use_case/DeleteReplyUseCase.js
@@ -1,0 +1,16 @@
+class DeleteReplyUseCase {
+  constructor({ threadRepository, commentRepository, replyRepository }) {
+    this._threadRepository = threadRepository;
+    this._commentRepository = commentRepository;
+    this._replyRepository = replyRepository;
+  }
+
+  async execute(threadId, commentId, replyId, owner) {
+    await this._threadRepository.verifyThreadExists(threadId);
+    await this._commentRepository.verifyCommentExists(commentId);
+    await this._replyRepository.verifyReplyOwner(replyId, owner);
+    await this._replyRepository.deleteReply(replyId);
+  }
+}
+
+module.exports = DeleteReplyUseCase;

--- a/src/Applications/use_case/GetThreadDetailUseCase.js
+++ b/src/Applications/use_case/GetThreadDetailUseCase.js
@@ -1,21 +1,39 @@
 class GetThreadDetailUseCase {
-  constructor({ threadRepository }) {
+  constructor({ threadRepository, commentRepository, replyRepository }) {
     this._threadRepository = threadRepository;
+    this._commentRepository = commentRepository;
+    this._replyRepository = replyRepository;
   }
 
   async execute(threadId) {
     const thread = await this._threadRepository.getThreadById(threadId);
-    const comments =
-      await this._threadRepository.getCommentsByThreadId(threadId);
+    const comments = await this._commentRepository.getCommentsByThreadId(threadId);
 
-    const formattedComments = comments.map((comment) => ({
-      id: comment.id,
-      username: comment.username,
-      date: comment.date,
-      content: comment.is_delete
-        ? "**komentar telah dihapus**"
-        : comment.content,
-    }));
+    const formattedComments = await Promise.all(
+      comments.map(async (comment) => {
+        const replies = await this._replyRepository.getRepliesByCommentId(comment.id);
+        
+        const formattedReplies = replies.map((reply) => ({
+          id: reply.id,
+          content: reply.is_delete
+            ? "**balasan telah dihapus**"
+            : reply.content,
+          date: reply.date,
+          username: reply.username,
+        }));
+
+        return {
+          id: comment.id,
+          username: comment.username,
+          date: comment.date,
+          content: comment.is_delete
+            ? "**komentar telah dihapus**"
+            : comment.content,
+          likeCount: parseInt(comment.like_count, 10),
+          replies: formattedReplies,
+        };
+      })
+    );
 
     return {
       ...thread,

--- a/src/Applications/use_case/LikeCommentUseCase.js
+++ b/src/Applications/use_case/LikeCommentUseCase.js
@@ -1,0 +1,24 @@
+class LikeCommentUseCase {
+  constructor({ commentRepository, threadRepository, commentLikeRepository }) {
+    this._commentRepository = commentRepository;
+    this._threadRepository = threadRepository;
+    this._commentLikeRepository = commentLikeRepository;
+  }
+
+  async execute(threadId, commentId, owner) {
+    await this._threadRepository.verifyThreadExists(threadId);
+    await this._commentRepository.verifyCommentExists(commentId);
+
+    const isLiked = await this._commentLikeRepository.verifyLikeExistence(commentId, owner);
+    
+    if (isLiked) {
+      // If like exists, unlike the comment
+      await this._commentLikeRepository.removeLike(commentId, owner);
+    } else {
+      // If like doesn't exist, like the comment
+      await this._commentLikeRepository.addLike(commentId, owner);
+    }
+  }
+}
+
+module.exports = LikeCommentUseCase;

--- a/src/Applications/use_case/ToggleCommentLikeUseCase.js
+++ b/src/Applications/use_case/ToggleCommentLikeUseCase.js
@@ -1,0 +1,24 @@
+class ToggleCommentLikeUseCase {
+  constructor({ commentRepository, commentLikeRepository }) {
+    this._commentRepository = commentRepository;
+    this._commentLikeRepository = commentLikeRepository;
+  }
+
+  async execute(threadId, commentId, owner) {
+    // Verify comment exists and belongs to the thread
+    await this._commentRepository.verifyCommentExists(commentId);
+    
+    // Check if user already liked this comment
+    const isLiked = await this._commentLikeRepository.verifyLikeExistence(commentId, owner);
+    
+    if (isLiked) {
+      // Unlike the comment
+      await this._commentLikeRepository.removeLike(commentId, owner);
+    } else {
+      // Like the comment
+      await this._commentLikeRepository.addLike(commentId, owner);
+    }
+  }
+}
+
+module.exports = ToggleCommentLikeUseCase;

--- a/src/Applications/use_case/_test/AddReplyUseCase.test.js
+++ b/src/Applications/use_case/_test/AddReplyUseCase.test.js
@@ -1,0 +1,75 @@
+const AddReplyUseCase = require("../AddReplyUseCase");
+const NewReply = require("../../../Domains/replies/entities/NewReply");
+const AddedReply = require("../../../Domains/replies/entities/AddedReply");
+
+// Create mocks
+const CommentRepository = require("../../../Domains/comments/CommentRepository");
+const ThreadRepository = require("../../../Domains/threads/ThreadRepository");
+const ReplyRepository = require("../../../Domains/replies/ReplyRepository");
+
+describe("AddReplyUseCase", () => {
+  let addReplyUseCase;
+  let mockCommentRepository;
+  let mockThreadRepository;
+  let mockReplyRepository;
+
+  beforeEach(() => {
+    // Mock repositories
+    mockCommentRepository = new CommentRepository();
+    mockThreadRepository = new ThreadRepository();
+    mockReplyRepository = new ReplyRepository();
+
+    // Create use case instance
+    addReplyUseCase = new AddReplyUseCase({
+      commentRepository: mockCommentRepository,
+      threadRepository: mockThreadRepository,
+      replyRepository: mockReplyRepository,
+    });
+  });
+
+  describe("execute function", () => {
+    it("should orchestrate the add reply correctly", async () => {
+      // Arrange
+      const useCasePayload = {
+        content: "sebuah balasan",
+      };
+      const expectedAddedReply = new AddedReply({
+        id: "reply-123",
+        content: useCasePayload.content,
+        owner: "user-123",
+      });
+
+      mockThreadRepository.verifyThreadExists = jest.fn().mockResolvedValue();
+      mockCommentRepository.verifyCommentExists = jest.fn().mockResolvedValue();
+      mockReplyRepository.addReply = jest.fn().mockResolvedValue(expectedAddedReply);
+
+      // Act
+      const addedReply = await addReplyUseCase.execute(
+        useCasePayload,
+        "comment-123",
+        "thread-123",
+        "user-123"
+      );
+
+      // Assert
+      expect(addedReply).toStrictEqual(expectedAddedReply);
+      expect(mockThreadRepository.verifyThreadExists).toBeCalledWith("thread-123");
+      expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-123");
+      expect(mockReplyRepository.addReply).toBeCalledWith(
+        new NewReply(useCasePayload),
+        "comment-123",
+        "user-123"
+      );
+    });
+
+    it("should throw error if payload is not valid", async () => {
+      // Arrange
+      const useCasePayload = {};
+
+      // Act & Assert
+      await expect(
+        addReplyUseCase.execute(useCasePayload, "comment-123", "thread-123", "user-123")
+      ).rejects.toThrowError("NEW_REPLY.NOT_CONTAIN_NEEDED_PROPERTY");
+    });
+  });
+});

--- a/src/Applications/use_case/_test/DeleteReplyUseCase.test.js
+++ b/src/Applications/use_case/_test/DeleteReplyUseCase.test.js
@@ -1,0 +1,46 @@
+const DeleteReplyUseCase = require("../DeleteReplyUseCase");
+
+// Create mocks
+const CommentRepository = require("../../../Domains/comments/CommentRepository");
+const ThreadRepository = require("../../../Domains/threads/ThreadRepository");
+const ReplyRepository = require("../../../Domains/replies/ReplyRepository");
+
+describe("DeleteReplyUseCase", () => {
+  let deleteReplyUseCase;
+  let mockCommentRepository;
+  let mockThreadRepository;
+  let mockReplyRepository;
+
+  beforeEach(() => {
+    // Mock repositories
+    mockCommentRepository = new CommentRepository();
+    mockThreadRepository = new ThreadRepository();
+    mockReplyRepository = new ReplyRepository();
+
+    // Create use case instance
+    deleteReplyUseCase = new DeleteReplyUseCase({
+      commentRepository: mockCommentRepository,
+      threadRepository: mockThreadRepository,
+      replyRepository: mockReplyRepository,
+    });
+  });
+
+  describe("execute function", () => {
+    it("should orchestrate the delete reply correctly", async () => {
+      // Arrange
+      mockThreadRepository.verifyThreadExists = jest.fn().mockResolvedValue();
+      mockCommentRepository.verifyCommentExists = jest.fn().mockResolvedValue();
+      mockReplyRepository.verifyReplyOwner = jest.fn().mockResolvedValue();
+      mockReplyRepository.deleteReply = jest.fn().mockResolvedValue();
+
+      // Act
+      await deleteReplyUseCase.execute("thread-123", "comment-123", "reply-123", "user-123");
+
+      // Assert
+      expect(mockThreadRepository.verifyThreadExists).toBeCalledWith("thread-123");
+      expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-123");
+      expect(mockReplyRepository.verifyReplyOwner).toBeCalledWith("reply-123", "user-123");
+      expect(mockReplyRepository.deleteReply).toBeCalledWith("reply-123");
+    });
+  });
+});

--- a/src/Applications/use_case/_test/GetThreadDetailUseCase.test.js
+++ b/src/Applications/use_case/_test/GetThreadDetailUseCase.test.js
@@ -19,6 +19,7 @@ describe("GetThreadDetailUseCase", () => {
         date: new Date("2023-01-01T01:00:00.000Z"),
         content: "A comment",
         is_delete: false,
+        like_count: 0,
       },
       {
         id: "comment-2",
@@ -26,16 +27,36 @@ describe("GetThreadDetailUseCase", () => {
         date: new Date("2023-01-01T02:00:00.000Z"),
         content: "Deleted comment",
         is_delete: true,
+        like_count: 0,
+      },
+    ];
+
+    const mockReplies = [
+      {
+        id: "reply-1",
+        username: "replier",
+        date: new Date("2023-01-01T03:00:00.000Z"),
+        content: "A reply",
+        is_delete: false,
       },
     ];
 
     const mockThreadRepository = {
       getThreadById: jest.fn(() => Promise.resolve(mockThread)),
+    };
+
+    const mockCommentRepository = {
       getCommentsByThreadId: jest.fn(() => Promise.resolve(mockComments)),
+    };
+
+    const mockReplyRepository = {
+      getRepliesByCommentId: jest.fn(() => Promise.resolve(mockReplies)),
     };
 
     const useCase = new GetThreadDetailUseCase({
       threadRepository: mockThreadRepository,
+      commentRepository: mockCommentRepository,
+      replyRepository: mockReplyRepository,
     });
 
     // Act
@@ -50,19 +71,39 @@ describe("GetThreadDetailUseCase", () => {
           username: "johndoe",
           date: new Date("2023-01-01T01:00:00.000Z"),
           content: "A comment",
+          likeCount: 0,
+          replies: [
+            {
+              id: "reply-1",
+              username: "replier",
+              date: new Date("2023-01-01T03:00:00.000Z"),
+              content: "A reply",
+            },
+          ],
         },
         {
           id: "comment-2",
           username: "janedoe",
           date: new Date("2023-01-01T02:00:00.000Z"),
           content: "**komentar telah dihapus**",
+          likeCount: 0,
+          replies: [
+            {
+              id: "reply-1",
+              username: "replier",
+              date: new Date("2023-01-01T03:00:00.000Z"),
+              content: "A reply",
+            },
+          ],
         },
       ],
     });
     expect(mockThreadRepository.getThreadById).toHaveBeenCalledWith(threadId);
-    expect(mockThreadRepository.getCommentsByThreadId).toHaveBeenCalledWith(
+    expect(mockCommentRepository.getCommentsByThreadId).toHaveBeenCalledWith(
       threadId,
     );
+    expect(mockReplyRepository.getRepliesByCommentId).toHaveBeenCalledWith("comment-1");
+    expect(mockReplyRepository.getRepliesByCommentId).toHaveBeenCalledWith("comment-2");
   });
 
   it("should throw NotFoundError if thread not found", async () => {
@@ -72,10 +113,20 @@ describe("GetThreadDetailUseCase", () => {
       getThreadById: jest.fn(() =>
         Promise.reject(new NotFoundError("thread tidak ditemukan")),
       ),
+    };
+    
+    const mockCommentRepository = {
       getCommentsByThreadId: jest.fn(),
     };
+
+    const mockReplyRepository = {
+      getRepliesByCommentId: jest.fn(),
+    };
+    
     const useCase = new GetThreadDetailUseCase({
       threadRepository: mockThreadRepository,
+      commentRepository: mockCommentRepository,
+      replyRepository: mockReplyRepository,
     });
 
     // Act & Assert

--- a/src/Applications/use_case/_test/LikeCommentUseCase.test.js
+++ b/src/Applications/use_case/_test/LikeCommentUseCase.test.js
@@ -1,0 +1,121 @@
+const LikeCommentUseCase = require("../LikeCommentUseCase");
+const CommentRepository = require("../../../Domains/comments/CommentRepository");
+const ThreadRepository = require("../../../Domains/threads/ThreadRepository");
+const CommentLikeRepository = require("../../../Domains/comments/CommentLikeRepository");
+
+describe("LikeCommentUseCase", () => {
+  it("should orchestrate the like comment action correctly when comment is not liked", async () => {
+    // Arrange
+    const mockCommentRepository = new CommentRepository();
+    const mockThreadRepository = new ThreadRepository();
+    const mockCommentLikeRepository = new CommentLikeRepository();
+
+    // Mocking
+    mockThreadRepository.verifyThreadExists = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+    mockCommentRepository.verifyCommentExists = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+    mockCommentLikeRepository.verifyLikeExistence = jest.fn()
+      .mockImplementation(() => Promise.resolve(false));
+    mockCommentLikeRepository.addLike = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+
+    // Create use case instance
+    const likeCommentUseCase = new LikeCommentUseCase({
+      commentRepository: mockCommentRepository,
+      threadRepository: mockThreadRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Action
+    await likeCommentUseCase.execute("thread-123", "comment-123", "user-123");
+
+    // Assert
+    expect(mockThreadRepository.verifyThreadExists).toBeCalledWith("thread-123");
+    expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-123");
+    expect(mockCommentLikeRepository.verifyLikeExistence).toBeCalledWith("comment-123", "user-123");
+    expect(mockCommentLikeRepository.addLike).toBeCalledWith("comment-123", "user-123");
+  });
+
+  it("should orchestrate the unlike comment action correctly when comment is already liked", async () => {
+    // Arrange
+    const mockCommentRepository = new CommentRepository();
+    const mockThreadRepository = new ThreadRepository();
+    const mockCommentLikeRepository = new CommentLikeRepository();
+
+    // Mocking
+    mockThreadRepository.verifyThreadExists = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+    mockCommentRepository.verifyCommentExists = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+    mockCommentLikeRepository.verifyLikeExistence = jest.fn()
+      .mockImplementation(() => Promise.resolve(true));
+    mockCommentLikeRepository.removeLike = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+
+    // Create use case instance
+    const likeCommentUseCase = new LikeCommentUseCase({
+      commentRepository: mockCommentRepository,
+      threadRepository: mockThreadRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Action
+    await likeCommentUseCase.execute("thread-123", "comment-123", "user-123");
+
+    // Assert
+    expect(mockThreadRepository.verifyThreadExists).toBeCalledWith("thread-123");
+    expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-123");
+    expect(mockCommentLikeRepository.verifyLikeExistence).toBeCalledWith("comment-123", "user-123");
+    expect(mockCommentLikeRepository.removeLike).toBeCalledWith("comment-123", "user-123");
+  });
+
+  it("should throw error when thread not found", async () => {
+    // Arrange
+    const mockCommentRepository = new CommentRepository();
+    const mockThreadRepository = new ThreadRepository();
+    const mockCommentLikeRepository = new CommentLikeRepository();
+
+    // Mocking
+    mockThreadRepository.verifyThreadExists = jest.fn()
+      .mockImplementation(() => Promise.reject(new Error("THREAD_REPOSITORY.THREAD_NOT_FOUND")));
+
+    // Create use case instance
+    const likeCommentUseCase = new LikeCommentUseCase({
+      commentRepository: mockCommentRepository,
+      threadRepository: mockThreadRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Action & Assert
+    await expect(likeCommentUseCase.execute("thread-123", "comment-123", "user-123"))
+      .rejects.toThrowError("THREAD_REPOSITORY.THREAD_NOT_FOUND");
+    expect(mockThreadRepository.verifyThreadExists).toBeCalledWith("thread-123");
+  });
+
+  it("should throw error when comment not found", async () => {
+    // Arrange
+    const mockCommentRepository = new CommentRepository();
+    const mockThreadRepository = new ThreadRepository();
+    const mockCommentLikeRepository = new CommentLikeRepository();
+
+    // Mocking
+    mockThreadRepository.verifyThreadExists = jest.fn()
+      .mockImplementation(() => Promise.resolve());
+    mockCommentRepository.verifyCommentExists = jest.fn()
+      .mockImplementation(() => Promise.reject(new Error("COMMENT_REPOSITORY.COMMENT_NOT_FOUND")));
+
+    // Create use case instance
+    const likeCommentUseCase = new LikeCommentUseCase({
+      commentRepository: mockCommentRepository,
+      threadRepository: mockThreadRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Action & Assert
+    await expect(likeCommentUseCase.execute("thread-123", "comment-123", "user-123"))
+      .rejects.toThrowError("COMMENT_REPOSITORY.COMMENT_NOT_FOUND");
+    expect(mockThreadRepository.verifyThreadExists).toBeCalledWith("thread-123");
+    expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-123");
+  });
+});

--- a/src/Applications/use_case/_test/ToggleCommentLikeUseCase.test.js
+++ b/src/Applications/use_case/_test/ToggleCommentLikeUseCase.test.js
@@ -1,0 +1,82 @@
+const ToggleCommentLikeUseCase = require("../ToggleCommentLikeUseCase");
+
+describe("ToggleCommentLikeUseCase", () => {
+  it("should orchestrate like comment action correctly when comment is not liked", async () => {
+    // Arrange
+    const mockCommentRepository = {
+      verifyCommentExists: jest.fn().mockResolvedValue(),
+    };
+    const mockCommentLikeRepository = {
+      verifyLikeExistence: jest.fn().mockResolvedValue(false),
+      addLike: jest.fn().mockResolvedValue(),
+      removeLike: jest.fn(),
+    };
+    
+    const useCase = new ToggleCommentLikeUseCase({
+      commentRepository: mockCommentRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Act
+    await useCase.execute("thread-1", "comment-1", "user-1");
+
+    // Assert
+    expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-1");
+    expect(mockCommentLikeRepository.verifyLikeExistence).toBeCalledWith("comment-1", "user-1");
+    expect(mockCommentLikeRepository.addLike).toBeCalledWith("comment-1", "user-1");
+    expect(mockCommentLikeRepository.removeLike).not.toBeCalled();
+  });
+
+  it("should orchestrate unlike comment action correctly when comment is already liked", async () => {
+    // Arrange
+    const mockCommentRepository = {
+      verifyCommentExists: jest.fn().mockResolvedValue(),
+    };
+    const mockCommentLikeRepository = {
+      verifyLikeExistence: jest.fn().mockResolvedValue(true),
+      addLike: jest.fn(),
+      removeLike: jest.fn().mockResolvedValue(),
+    };
+    
+    const useCase = new ToggleCommentLikeUseCase({
+      commentRepository: mockCommentRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Act
+    await useCase.execute("thread-1", "comment-1", "user-1");
+
+    // Assert
+    expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-1");
+    expect(mockCommentLikeRepository.verifyLikeExistence).toBeCalledWith("comment-1", "user-1");
+    expect(mockCommentLikeRepository.removeLike).toBeCalledWith("comment-1", "user-1");
+    expect(mockCommentLikeRepository.addLike).not.toBeCalled();
+  });
+
+  it("should throw error if comment does not exist", async () => {
+    // Arrange
+    const mockCommentRepository = {
+      verifyCommentExists: jest.fn(() =>
+        Promise.reject(new Error("COMMENT_REPOSITORY.COMMENT_NOT_FOUND"))
+      ),
+    };
+    const mockCommentLikeRepository = {
+      verifyLikeExistence: jest.fn(),
+      addLike: jest.fn(),
+      removeLike: jest.fn(),
+    };
+    
+    const useCase = new ToggleCommentLikeUseCase({
+      commentRepository: mockCommentRepository,
+      commentLikeRepository: mockCommentLikeRepository,
+    });
+
+    // Act & Assert
+    await expect(
+      useCase.execute("thread-1", "comment-1", "user-1")
+    ).rejects.toThrow("COMMENT_REPOSITORY.COMMENT_NOT_FOUND");
+    
+    expect(mockCommentRepository.verifyCommentExists).toBeCalledWith("comment-1");
+    expect(mockCommentLikeRepository.verifyLikeExistence).not.toBeCalled();
+  });
+});

--- a/src/Commons/exceptions/DomainErrorTranslator.js
+++ b/src/Commons/exceptions/DomainErrorTranslator.js
@@ -64,6 +64,20 @@ DomainErrorTranslator._directories = {
   "COMMENT_REPOSITORY.NOT_THE_OWNER": new AuthorizationError(
     "anda tidak berhak mengakses resource ini",
   ),
+
+  // Reply errors
+  "NEW_REPLY.NOT_CONTAIN_NEEDED_PROPERTY": new InvariantError(
+    "tidak dapat membuat balasan baru karena properti yang dibutuhkan tidak ada",
+  ),
+  "NEW_REPLY.NOT_MEET_DATA_TYPE_SPECIFICATION": new InvariantError(
+    "tidak dapat membuat balasan baru karena tipe data tidak sesuai",
+  ),
+  "REPLY_REPOSITORY.REPLY_NOT_FOUND": new NotFoundError(
+    "balasan tidak ditemukan",
+  ),
+  "REPLY_REPOSITORY.NOT_THE_OWNER": new AuthorizationError(
+    "anda tidak berhak mengakses resource ini",
+  ),
 };
 
 module.exports = DomainErrorTranslator;

--- a/src/Domains/comments/CommentLikeRepository.js
+++ b/src/Domains/comments/CommentLikeRepository.js
@@ -1,0 +1,19 @@
+class CommentLikeRepository {
+  async addLike(commentId, owner) {
+    throw new Error("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+
+  async removeLike(commentId, owner) {
+    throw new Error("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+
+  async verifyLikeExistence(commentId, owner) {
+    throw new Error("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+
+  async getLikeCountByCommentId(commentId) {
+    throw new Error("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+}
+
+module.exports = CommentLikeRepository;

--- a/src/Domains/comments/CommentRepository.js
+++ b/src/Domains/comments/CommentRepository.js
@@ -14,6 +14,22 @@ class CommentRepository {
   async getCommentsByThreadId(threadId) {
     throw new Error("COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED");
   }
+
+  async verifyCommentExists(commentId) {
+    throw new Error("COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+
+  async likeComment(commentId, owner) {
+    throw new Error("COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+
+  async unlikeComment(commentId, owner) {
+    throw new Error("COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
+
+  async verifyCommentLike(commentId, owner) {
+    throw new Error("COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
 }
 
 module.exports = CommentRepository;

--- a/src/Domains/comments/_test/CommentLikeRepository.test.js
+++ b/src/Domains/comments/_test/CommentLikeRepository.test.js
@@ -1,0 +1,23 @@
+const CommentLikeRepository = require("../CommentLikeRepository");
+
+describe("CommentLikeRepository interface", () => {
+  it("should throw error when invoke unimplemented methods", async () => {
+    const repo = new CommentLikeRepository();
+    
+    await expect(
+      repo.addLike("comment-1", "user-1"),
+    ).rejects.toThrowError("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+    
+    await expect(
+      repo.removeLike("comment-1", "user-1"),
+    ).rejects.toThrowError("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+    
+    await expect(
+      repo.verifyLikeExistence("comment-1", "user-1"),
+    ).rejects.toThrowError("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+    
+    await expect(
+      repo.getLikeCountByCommentId("comment-1"),
+    ).rejects.toThrowError("COMMENT_LIKE_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  });
+});

--- a/src/Domains/comments/_test/CommentRepository.test.js
+++ b/src/Domains/comments/_test/CommentRepository.test.js
@@ -15,5 +15,17 @@ describe("CommentRepository interface", () => {
     await expect(repo.getCommentsByThreadId("thread-1")).rejects.toThrowError(
       "COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED",
     );
+    await expect(repo.verifyCommentExists("comment-1")).rejects.toThrowError(
+      "COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED",
+    );
+    await expect(repo.likeComment("comment-1", "user-1")).rejects.toThrowError(
+      "COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED",
+    );
+    await expect(repo.unlikeComment("comment-1", "user-1")).rejects.toThrowError(
+      "COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED",
+    );
+    await expect(repo.verifyCommentLike("comment-1", "user-1")).rejects.toThrowError(
+      "COMMENT_REPOSITORY.METHOD_NOT_IMPLEMENTED",
+    );
   });
 });

--- a/src/Domains/comments/entities/CommentLike.js
+++ b/src/Domains/comments/entities/CommentLike.js
@@ -1,0 +1,23 @@
+class CommentLike {
+  constructor(payload) {
+    this._verifyPayload(payload);
+
+    const { id, commentId, owner } = payload;
+    
+    this.id = id;
+    this.commentId = commentId;
+    this.owner = owner;
+  }
+
+  _verifyPayload({ id, commentId, owner }) {
+    if (!id || !commentId || !owner) {
+      throw new Error("COMMENT_LIKE.NOT_CONTAIN_NEEDED_PROPERTY");
+    }
+
+    if (typeof id !== "string" || typeof commentId !== "string" || typeof owner !== "string") {
+      throw new Error("COMMENT_LIKE.NOT_MEET_DATA_TYPE_SPECIFICATION");
+    }
+  }
+}
+
+module.exports = CommentLike;

--- a/src/Domains/comments/entities/_test/CommentLike.test.js
+++ b/src/Domains/comments/entities/_test/CommentLike.test.js
@@ -1,0 +1,40 @@
+const CommentLike = require("../CommentLike");
+
+describe("CommentLike entity", () => {
+  it("should throw error when payload missing required properties", () => {
+    const payload = {
+      id: "like-123",
+      commentId: "comment-123",
+    };
+
+    expect(() => new CommentLike(payload)).toThrowError(
+      "COMMENT_LIKE.NOT_CONTAIN_NEEDED_PROPERTY",
+    );
+  });
+
+  it("should throw error when payload not meet data type specification", () => {
+    const payload = {
+      id: 123,
+      commentId: "comment-123",
+      owner: "user-123",
+    };
+
+    expect(() => new CommentLike(payload)).toThrowError(
+      "COMMENT_LIKE.NOT_MEET_DATA_TYPE_SPECIFICATION",
+    );
+  });
+
+  it("should create CommentLike object correctly", () => {
+    const payload = {
+      id: "like-123",
+      commentId: "comment-123",
+      owner: "user-123",
+    };
+
+    const commentLike = new CommentLike(payload);
+
+    expect(commentLike.id).toEqual(payload.id);
+    expect(commentLike.commentId).toEqual(payload.commentId);
+    expect(commentLike.owner).toEqual(payload.owner);
+  });
+});

--- a/src/Domains/replies/ReplyRepository.js
+++ b/src/Domains/replies/ReplyRepository.js
@@ -1,0 +1,23 @@
+class ReplyRepository {
+  async addReply(newReply, commentId, owner) {
+    throw new Error('REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED');
+  }
+
+  async deleteReply(replyId) {
+    throw new Error('REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED');
+  }
+
+  async verifyReplyOwner(replyId, owner) {
+    throw new Error('REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED');
+  }
+
+  async verifyReplyExists(replyId) {
+    throw new Error('REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED');
+  }
+
+  async getRepliesByCommentId(commentId) {
+    throw new Error('REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED');
+  }
+}
+
+module.exports = ReplyRepository;

--- a/src/Domains/replies/_test/ReplyRepository.test.js
+++ b/src/Domains/replies/_test/ReplyRepository.test.js
@@ -1,0 +1,25 @@
+const ReplyRepository = require("../ReplyRepository");
+
+describe("ReplyRepository interface", () => {
+  it("should throw error when invoke abstract behavior", async () => {
+    // Arrange
+    const replyRepository = new ReplyRepository();
+
+    // Action & Assert
+    await expect(replyRepository.addReply({}, "", "")).rejects.toThrowError(
+      "REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED"
+    );
+    await expect(replyRepository.deleteReply("")).rejects.toThrowError(
+      "REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED"
+    );
+    await expect(replyRepository.verifyReplyOwner("", "")).rejects.toThrowError(
+      "REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED"
+    );
+    await expect(replyRepository.verifyReplyExists("")).rejects.toThrowError(
+      "REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED"
+    );
+    await expect(replyRepository.getRepliesByCommentId("")).rejects.toThrowError(
+      "REPLY_REPOSITORY.METHOD_NOT_IMPLEMENTED"
+    );
+  });
+});

--- a/src/Domains/replies/entities/AddedReply.js
+++ b/src/Domains/replies/entities/AddedReply.js
@@ -1,0 +1,23 @@
+class AddedReply {
+  constructor(payload) {
+    this._verifyPayload(payload);
+
+    const { id, content, owner } = payload;
+
+    this.id = id;
+    this.content = content;
+    this.owner = owner;
+  }
+
+  _verifyPayload({ id, content, owner }) {
+    if (!id || !content || !owner) {
+      throw new Error('ADDED_REPLY.NOT_CONTAIN_NEEDED_PROPERTY');
+    }
+
+    if (typeof id !== 'string' || typeof content !== 'string' || typeof owner !== 'string') {
+      throw new Error('ADDED_REPLY.NOT_MEET_DATA_TYPE_SPECIFICATION');
+    }
+  }
+}
+
+module.exports = AddedReply;

--- a/src/Domains/replies/entities/NewReply.js
+++ b/src/Domains/replies/entities/NewReply.js
@@ -1,0 +1,21 @@
+class NewReply {
+  constructor(payload) {
+    this._verifyPayload(payload);
+
+    const { content } = payload;
+
+    this.content = content;
+  }
+
+  _verifyPayload({ content }) {
+    if (!content) {
+      throw new Error('NEW_REPLY.NOT_CONTAIN_NEEDED_PROPERTY');
+    }
+
+    if (typeof content !== 'string') {
+      throw new Error('NEW_REPLY.NOT_MEET_DATA_TYPE_SPECIFICATION');
+    }
+  }
+}
+
+module.exports = NewReply;

--- a/src/Domains/replies/entities/_test/AddedReply.test.js
+++ b/src/Domains/replies/entities/_test/AddedReply.test.js
@@ -1,0 +1,49 @@
+const AddedReply = require("../AddedReply");
+
+describe("AddedReply entities", () => {
+  it("should throw error when payload does not contain needed property", () => {
+    // Arrange
+    const payload = {
+      id: "reply-123",
+      content: "sebuah balasan",
+    };
+
+    // Action & Assert
+    expect(() => new AddedReply(payload)).toThrowError(
+      "ADDED_REPLY.NOT_CONTAIN_NEEDED_PROPERTY"
+    );
+  });
+
+  it("should throw error when payload does not meet data type specification", () => {
+    // Arrange
+    const payload = {
+      id: 123,
+      content: "sebuah balasan",
+      owner: "user-123",
+    };
+
+    // Action & Assert
+    expect(() => new AddedReply(payload)).toThrowError(
+      "ADDED_REPLY.NOT_MEET_DATA_TYPE_SPECIFICATION"
+    );
+  });
+
+  it("should create AddedReply entities correctly", () => {
+    // Arrange
+    const payload = {
+      id: "reply-123",
+      content: "sebuah balasan",
+      owner: "user-123",
+    };
+
+    // Action
+    const addedReply = new AddedReply(payload);
+
+    // Assert
+    expect(addedReply).toEqual({
+      id: "reply-123",
+      content: "sebuah balasan",
+      owner: "user-123",
+    });
+  });
+});

--- a/src/Domains/replies/entities/_test/NewReply.test.js
+++ b/src/Domains/replies/entities/_test/NewReply.test.js
@@ -1,0 +1,38 @@
+const NewReply = require("../NewReply");
+
+describe("NewReply entities", () => {
+  it("should throw error when payload does not contain needed property", () => {
+    // Arrange
+    const payload = {};
+
+    // Action & Assert
+    expect(() => new NewReply(payload)).toThrowError(
+      "NEW_REPLY.NOT_CONTAIN_NEEDED_PROPERTY"
+    );
+  });
+
+  it("should throw error when payload does not meet data type specification", () => {
+    // Arrange
+    const payload = {
+      content: 123,
+    };
+
+    // Action & Assert
+    expect(() => new NewReply(payload)).toThrowError(
+      "NEW_REPLY.NOT_MEET_DATA_TYPE_SPECIFICATION"
+    );
+  });
+
+  it("should create NewReply entities correctly", () => {
+    // Arrange
+    const payload = {
+      content: "sebuah balasan",
+    };
+
+    // Action
+    const newReply = new NewReply(payload);
+
+    // Assert
+    expect(newReply.content).toEqual(payload.content);
+  });
+});

--- a/src/Domains/threads/ThreadRepository.js
+++ b/src/Domains/threads/ThreadRepository.js
@@ -8,6 +8,9 @@ class ThreadRepository {
   async getCommentsByThreadId(threadId) {
     throw new Error("THREAD_REPOSITORY.METHOD_NOT_IMPLEMENTED");
   }
+  async verifyThreadExists(threadId) {
+    throw new Error("THREAD_REPOSITORY.METHOD_NOT_IMPLEMENTED");
+  }
 }
 
 module.exports = ThreadRepository;

--- a/src/Infrastructures/container.js
+++ b/src/Infrastructures/container.js
@@ -20,6 +20,12 @@ const ThreadRepositoryPostgres = require("./repository/ThreadRepositoryPostgres"
 const CommentRepository = require("../Domains/comments/CommentRepository");
 const CommentRepositoryPostgres = require("./repository/CommentRepositoryPostgres");
 
+const CommentLikeRepository = require("../Domains/comments/CommentLikeRepository");
+const CommentLikeRepositoryPostgres = require("./repository/CommentLikeRepositoryPostgres");
+
+const ReplyRepository = require("../Domains/replies/ReplyRepository");
+const ReplyRepositoryPostgres = require("./repository/ReplyRepositoryPostgres");
+
 const AuthenticationRepository = require("../Domains/authentications/AuthenticationRepository");
 const AuthenticationRepositoryPostgres = require("./repository/AuthenticationRepositoryPostgres");
 
@@ -36,6 +42,10 @@ const GetThreadDetailUseCase = require("../Applications/use_case/GetThreadDetail
 
 const AddCommentUseCase = require("../Applications/use_case/AddCommentUseCase");
 const DeleteCommentUseCase = require("../Applications/use_case/DeleteCommentUseCase");
+const LikeCommentUseCase = require("../Applications/use_case/LikeCommentUseCase");
+
+const AddReplyUseCase = require("../Applications/use_case/AddReplyUseCase");
+const DeleteReplyUseCase = require("../Applications/use_case/DeleteReplyUseCase");
 
 // creating container
 const container = createContainer();
@@ -80,6 +90,20 @@ container.register([
   {
     key: CommentRepository.name,
     Class: CommentRepositoryPostgres,
+    parameter: {
+      dependencies: [{ concrete: pool }, { concrete: nanoid }],
+    },
+  },
+  {
+    key: CommentLikeRepository.name,
+    Class: CommentLikeRepositoryPostgres,
+    parameter: {
+      dependencies: [{ concrete: pool }, { concrete: nanoid }],
+    },
+  },
+  {
+    key: ReplyRepository.name,
+    Class: ReplyRepositoryPostgres,
     parameter: {
       dependencies: [{ concrete: pool }, { concrete: nanoid }],
     },
@@ -165,6 +189,8 @@ container.register([
       injectType: "destructuring",
       dependencies: [
         { name: "threadRepository", internal: ThreadRepository.name },
+        { name: "commentRepository", internal: CommentRepository.name },
+        { name: "replyRepository", internal: ReplyRepository.name },
       ],
     },
   },
@@ -186,6 +212,42 @@ container.register([
       injectType: "destructuring",
       dependencies: [
         { name: "commentRepository", internal: CommentRepository.name },
+      ],
+    },
+  },
+  {
+    key: LikeCommentUseCase.name,
+    Class: LikeCommentUseCase,
+    parameter: {
+      injectType: "destructuring",
+      dependencies: [
+        { name: "commentRepository", internal: CommentRepository.name },
+        { name: "threadRepository", internal: ThreadRepository.name },
+        { name: "commentLikeRepository", internal: CommentLikeRepository.name },
+      ],
+    },
+  },
+  {
+    key: AddReplyUseCase.name,
+    Class: AddReplyUseCase,
+    parameter: {
+      injectType: "destructuring",
+      dependencies: [
+        { name: "commentRepository", internal: CommentRepository.name },
+        { name: "threadRepository", internal: ThreadRepository.name },
+        { name: "replyRepository", internal: ReplyRepository.name },
+      ],
+    },
+  },
+  {
+    key: DeleteReplyUseCase.name,
+    Class: DeleteReplyUseCase,
+    parameter: {
+      injectType: "destructuring",
+      dependencies: [
+        { name: "commentRepository", internal: CommentRepository.name },
+        { name: "threadRepository", internal: ThreadRepository.name },
+        { name: "replyRepository", internal: ReplyRepository.name },
       ],
     },
   },

--- a/src/Infrastructures/http/_test/comment-likes.test.js
+++ b/src/Infrastructures/http/_test/comment-likes.test.js
@@ -1,0 +1,371 @@
+const pool = require("../../database/postgres/pool");
+const createServer = require("../createServer");
+const container = require("../../container");
+
+// Helper functions for setup/teardown
+const UsersTableTestHelper = require("../../../../tests/UsersTableTestHelper");
+const ThreadsTableTestHelper = require("../../../../tests/ThreadsTableTestHelper");
+const CommentsTableTestHelper = require("../../../../tests/CommentsTableTestHelper");
+const CommentLikesTableTestHelper = require("../../../../tests/CommentLikesTableTestHelper");
+const AuthenticationsTableTestHelper = require("../../../../tests/AuthenticationsTableTestHelper");
+
+describe("/threads/{threadId}/comments/{commentId}/likes endpoint", () => {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await CommentLikesTableTestHelper.cleanTable();
+    await CommentsTableTestHelper.cleanTable();
+    await ThreadsTableTestHelper.cleanTable();
+    await AuthenticationsTableTestHelper.cleanTable();
+    await UsersTableTestHelper.cleanTable();
+  });
+
+  describe("when PUT /threads/{threadId}/comments/{commentId}/likes", () => {
+    it("should response 200 when user like comment", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "PUT",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/likes`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(200);
+      expect(responseJson.status).toEqual("success");
+    });
+
+    it("should response 200 when user unlike comment", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Like comment first
+      await server.inject({
+        method: "PUT",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/likes`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Act - Unlike comment
+      const response = await server.inject({
+        method: "PUT",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/likes`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(200);
+      expect(responseJson.status).toEqual("success");
+    });
+
+    it("should response 401 when missing authentication", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Act
+      const response = await server.inject({
+        method: "PUT",
+        url: "/threads/thread-123/comments/comment-123/likes",
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(401);
+    });
+
+    it("should response 404 when comment not found", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "PUT",
+        url: `/threads/${addedThread.id}/comments/comment-123/likes`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(404);
+    });
+  });
+
+  describe("when GET /threads/{threadId} with likes", () => {
+    it("should show like count in comments", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add users
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "johndoe",
+          password: "secret",
+          fullname: "John Doe",
+        },
+      });
+
+      // Login users
+      const loginResponse1 = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const loginResponse2 = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "johndoe",
+          password: "secret",
+        },
+      });
+
+      const accessToken1 = JSON.parse(loginResponse1.payload).data.accessToken;
+      const accessToken2 = JSON.parse(loginResponse2.payload).data.accessToken;
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken1}`,
+        },
+      });
+
+      const threadId = JSON.parse(threadResponse.payload).data.addedThread.id;
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${threadId}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken1}`,
+        },
+      });
+
+      const commentId = JSON.parse(commentResponse.payload).data.addedComment.id;
+
+      // Like comment from both users
+      await server.inject({
+        method: "PUT",
+        url: `/threads/${threadId}/comments/${commentId}/likes`,
+        headers: {
+          Authorization: `Bearer ${accessToken1}`,
+        },
+      });
+
+      await server.inject({
+        method: "PUT",
+        url: `/threads/${threadId}/comments/${commentId}/likes`,
+        headers: {
+          Authorization: `Bearer ${accessToken2}`,
+        },
+      });
+
+      // Act
+      const response = await server.inject({
+        method: "GET",
+        url: `/threads/${threadId}`,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(200);
+      expect(responseJson.status).toEqual("success");
+      expect(responseJson.data.thread.comments).toHaveLength(1);
+      expect(responseJson.data.thread.comments[0].likeCount).toEqual(2);
+    });
+  });
+});

--- a/src/Infrastructures/http/_test/replies.test.js
+++ b/src/Infrastructures/http/_test/replies.test.js
@@ -1,0 +1,906 @@
+const pool = require("../../database/postgres/pool");
+const createServer = require("../createServer");
+const container = require("../../container");
+
+// Helper functions for setup/teardown
+const UsersTableTestHelper = require("../../../../tests/UsersTableTestHelper");
+const ThreadsTableTestHelper = require("../../../../tests/ThreadsTableTestHelper");
+const CommentsTableTestHelper = require("../../../../tests/CommentsTableTestHelper");
+const RepliesTableTestHelper = require("../../../../tests/RepliesTableTestHelper");
+const AuthenticationsTableTestHelper = require("../../../../tests/AuthenticationsTableTestHelper");
+
+describe("/threads/{threadId}/comments/{commentId}/replies endpoint", () => {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await RepliesTableTestHelper.cleanTable();
+    await CommentsTableTestHelper.cleanTable();
+    await ThreadsTableTestHelper.cleanTable();
+    await AuthenticationsTableTestHelper.cleanTable();
+    await UsersTableTestHelper.cleanTable();
+  });
+
+  describe("when POST /threads/{threadId}/comments/{commentId}/replies", () => {
+    it("should response 201 and persist reply", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies`,
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(201);
+      expect(responseJson.status).toEqual("success");
+      expect(responseJson.data.addedReply).toBeDefined();
+      expect(responseJson.data.addedReply.id).toBeDefined();
+      expect(responseJson.data.addedReply.content).toEqual("Reply content");
+      expect(responseJson.data.addedReply.owner).toBeDefined();
+    });
+
+    it("should response 400 when request payload not contain needed property", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies`,
+        payload: {}, // Missing content
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(400);
+    });
+
+    it("should response 401 when request not contain access token", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Act
+      const response = await server.inject({
+        method: "POST",
+        url: "/threads/thread-123/comments/comment-123/replies",
+        payload: {
+          content: "Reply content",
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(401);
+    });
+
+    it("should response 404 when thread not found", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "POST",
+        url: "/threads/thread-123/comments/comment-123/replies",
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(404);
+    });
+
+    it("should response 404 when comment not found", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/comment-123/replies`,
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(404);
+    });
+  });
+
+  describe("when DELETE /threads/{threadId}/comments/{commentId}/replies/{replyId}", () => {
+    it("should response 200 and soft delete reply", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Add reply
+      const replyResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies`,
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedReply },
+      } = JSON.parse(replyResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies/${addedReply.id}`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(200);
+      expect(responseJson.status).toEqual("success");
+    });
+
+    it("should response 401 when request not contain access token", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Act
+      const response = await server.inject({
+        method: "DELETE",
+        url: "/threads/thread-123/comments/comment-123/replies/reply-123",
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(401);
+    });
+
+    it("should response 403 when user is not reply owner", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add first user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Add second user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "johndoe",
+          password: "secret",
+          fullname: "John Doe",
+        },
+      });
+
+      // Login first user
+      const loginResponse1 = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      // Login second user
+      const loginResponse2 = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "johndoe",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken: accessToken1 },
+      } = JSON.parse(loginResponse1.payload);
+
+      const {
+        data: { accessToken: accessToken2 },
+      } = JSON.parse(loginResponse2.payload);
+
+      // Add thread with first user
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken1}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment with first user
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken1}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Add reply with first user
+      const replyResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies`,
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken1}`,
+        },
+      });
+
+      const {
+        data: { addedReply },
+      } = JSON.parse(replyResponse.payload);
+
+      // Act - try to delete with second user
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies/${addedReply.id}`,
+        headers: {
+          Authorization: `Bearer ${accessToken2}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(403);
+    });
+
+    it("should response 404 when thread not found", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "DELETE",
+        url: "/threads/thread-123/comments/comment-123/replies/reply-123",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(404);
+    });
+
+    it("should response 404 when comment not found", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/threads/${addedThread.id}/comments/comment-123/replies/reply-123`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(404);
+    });
+
+    it("should response 404 when reply not found", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Act
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies/reply-123`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Assert
+      expect(response.statusCode).toEqual(404);
+    });
+  });
+
+  describe("when GET /threads/{threadId} with replies", () => {
+    it("should show replies in comments", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Add reply
+      await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies`,
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Act
+      const response = await server.inject({
+        method: "GET",
+        url: `/threads/${addedThread.id}`,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(200);
+      expect(responseJson.status).toEqual("success");
+      expect(responseJson.data.thread.comments).toHaveLength(1);
+      expect(responseJson.data.thread.comments[0].replies).toHaveLength(1);
+      expect(responseJson.data.thread.comments[0].replies[0].content).toEqual("Reply content");
+      expect(responseJson.data.thread.comments[0].replies[0].username).toEqual("dicoding");
+    });
+
+    it("should show deleted replies with **balasan telah dihapus** content", async () => {
+      // Arrange
+      const server = await createServer(container);
+
+      // Add user
+      await server.inject({
+        method: "POST",
+        url: "/users",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+          fullname: "Dicoding Indonesia",
+        },
+      });
+
+      // Login user
+      const loginResponse = await server.inject({
+        method: "POST",
+        url: "/authentications",
+        payload: {
+          username: "dicoding",
+          password: "secret",
+        },
+      });
+
+      const {
+        data: { accessToken },
+      } = JSON.parse(loginResponse.payload);
+
+      // Add thread
+      const threadResponse = await server.inject({
+        method: "POST",
+        url: "/threads",
+        payload: {
+          title: "Thread title",
+          body: "Thread body",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedThread },
+      } = JSON.parse(threadResponse.payload);
+
+      // Add comment
+      const commentResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments`,
+        payload: {
+          content: "Comment content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedComment },
+      } = JSON.parse(commentResponse.payload);
+
+      // Add reply
+      const replyResponse = await server.inject({
+        method: "POST",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies`,
+        payload: {
+          content: "Reply content",
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const {
+        data: { addedReply },
+      } = JSON.parse(replyResponse.payload);
+
+      // Delete reply
+      await server.inject({
+        method: "DELETE",
+        url: `/threads/${addedThread.id}/comments/${addedComment.id}/replies/${addedReply.id}`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      // Act
+      const response = await server.inject({
+        method: "GET",
+        url: `/threads/${addedThread.id}`,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(200);
+      expect(responseJson.status).toEqual("success");
+      expect(responseJson.data.thread.comments).toHaveLength(1);
+      expect(responseJson.data.thread.comments[0].replies).toHaveLength(1);
+      expect(responseJson.data.thread.comments[0].replies[0].content).toEqual("**balasan telah dihapus**");
+      expect(responseJson.data.thread.comments[0].replies[0].username).toEqual("dicoding");
+    });
+  });
+});

--- a/src/Infrastructures/http/createServer.js
+++ b/src/Infrastructures/http/createServer.js
@@ -6,6 +6,7 @@ const users = require("../../Interfaces/http/api/users");
 const authentications = require("../../Interfaces/http/api/authentications");
 const threads = require("../../Interfaces/http/api/threads");
 const comments = require("../../Interfaces/http/api/comments");
+const replies = require("../../Interfaces/http/api/replies");
 
 const createServer = async (container) => {
   const server = Hapi.server({
@@ -62,6 +63,10 @@ const createServer = async (container) => {
     },
     {
       plugin: comments, // <-- ADD THIS
+      options: { container },
+    },
+    {
+      plugin: replies,
       options: { container },
     },
   ]);

--- a/src/Infrastructures/repository/CommentLikeRepositoryPostgres.js
+++ b/src/Infrastructures/repository/CommentLikeRepositoryPostgres.js
@@ -1,0 +1,51 @@
+const CommentLikeRepository = require("../../Domains/comments/CommentLikeRepository");
+const { nanoid } = require("nanoid");
+
+class CommentLikeRepositoryPostgres extends CommentLikeRepository {
+  constructor(pool, idGenerator = nanoid) {
+    super();
+    this._pool = pool;
+    this._idGenerator = idGenerator;
+  }
+
+  async addLike(commentId, owner) {
+    const id = `like-${this._idGenerator()}`;
+    const query = {
+      text: "INSERT INTO comment_likes (id, comment_id, owner, date) VALUES ($1, $2, $3, NOW()) RETURNING id",
+      values: [id, commentId, owner],
+    };
+    const result = await this._pool.query(query);
+    return result.rows[0];
+  }
+
+  async removeLike(commentId, owner) {
+    const query = {
+      text: "DELETE FROM comment_likes WHERE comment_id = $1 AND owner = $2 RETURNING id",
+      values: [commentId, owner],
+    };
+    const result = await this._pool.query(query);
+    if (!result.rowCount) {
+      throw new Error("COMMENT_LIKE_REPOSITORY.LIKE_NOT_FOUND");
+    }
+  }
+
+  async verifyLikeExistence(commentId, owner) {
+    const query = {
+      text: "SELECT id FROM comment_likes WHERE comment_id = $1 AND owner = $2",
+      values: [commentId, owner],
+    };
+    const result = await this._pool.query(query);
+    return result.rowCount > 0;
+  }
+
+  async getLikeCountByCommentId(commentId) {
+    const query = {
+      text: "SELECT COUNT(*) as count FROM comment_likes WHERE comment_id = $1",
+      values: [commentId],
+    };
+    const result = await this._pool.query(query);
+    return parseInt(result.rows[0].count, 10);
+  }
+}
+
+module.exports = CommentLikeRepositoryPostgres;

--- a/src/Infrastructures/repository/ReplyRepositoryPostgres.js
+++ b/src/Infrastructures/repository/ReplyRepositoryPostgres.js
@@ -1,0 +1,78 @@
+const ReplyRepository = require('../../Domains/replies/ReplyRepository');
+const AddedReply = require('../../Domains/replies/entities/AddedReply');
+const { nanoid } = require('nanoid');
+
+class ReplyRepositoryPostgres extends ReplyRepository {
+  constructor(pool, idGenerator = nanoid) {
+    super();
+    this._pool = pool;
+    this._idGenerator = idGenerator;
+  }
+
+  async addReply(newReply, commentId, owner) {
+    const { content } = newReply;
+    const id = `reply-${this._idGenerator()}`;
+    const query = {
+      text: `INSERT INTO replies (id, content, comment_id, owner, is_delete, date)
+             VALUES ($1, $2, $3, $4, false, NOW())
+             RETURNING id, content, owner`,
+      values: [id, content, commentId, owner],
+    };
+    const result = await this._pool.query(query);
+    return new AddedReply(result.rows[0]);
+  }
+
+  async deleteReply(replyId) {
+    const query = {
+      text: 'UPDATE replies SET is_delete = true WHERE id = $1 RETURNING id',
+      values: [replyId],
+    };
+    const result = await this._pool.query(query);
+    if (!result.rowCount) {
+      throw new Error('REPLY_REPOSITORY.REPLY_NOT_FOUND');
+    }
+  }
+
+  async verifyReplyOwner(replyId, owner) {
+    const query = {
+      text: 'SELECT owner FROM replies WHERE id = $1',
+      values: [replyId],
+    };
+    const result = await this._pool.query(query);
+    if (!result.rowCount) {
+      throw new Error('REPLY_REPOSITORY.REPLY_NOT_FOUND');
+    }
+    if (result.rows[0].owner !== owner) {
+      throw new Error('REPLY_REPOSITORY.NOT_THE_OWNER');
+    }
+  }
+
+  async verifyReplyExists(replyId) {
+    const query = {
+      text: 'SELECT id FROM replies WHERE id = $1',
+      values: [replyId],
+    };
+    const result = await this._pool.query(query);
+    if (!result.rowCount) {
+      throw new Error('REPLY_REPOSITORY.REPLY_NOT_FOUND');
+    }
+  }
+
+  async getRepliesByCommentId(commentId) {
+    const query = {
+      text: `SELECT r.id, r.content, r.date, r.is_delete, u.username
+             FROM replies r
+             LEFT JOIN users u ON r.owner = u.id
+             WHERE r.comment_id = $1
+             ORDER BY r.date ASC`,
+      values: [commentId],
+    };
+    const result = await this._pool.query(query);
+    return result.rows.map((row) => ({
+      ...row,
+      date: row.date,
+    }));
+  }
+}
+
+module.exports = ReplyRepositoryPostgres;

--- a/src/Infrastructures/repository/_test/CommentLikeRepositoryPostgres.test.js
+++ b/src/Infrastructures/repository/_test/CommentLikeRepositoryPostgres.test.js
@@ -1,0 +1,165 @@
+const pool = require("../../database/postgres/pool");
+const CommentLikeRepositoryPostgres = require("../CommentLikeRepositoryPostgres");
+
+// Helper functions for setup/teardown
+const UsersTableTestHelper = require("../../../../tests/UsersTableTestHelper");
+const ThreadsTableTestHelper = require("../../../../tests/ThreadsTableTestHelper");
+const CommentsTableTestHelper = require("../../../../tests/CommentsTableTestHelper");
+const CommentLikesTableTestHelper = require("../../../../tests/CommentLikesTableTestHelper");
+
+describe("CommentLikeRepositoryPostgres", () => {
+  beforeAll(async () => {
+    // Insert a user, thread, and comment for foreign key constraints
+    await UsersTableTestHelper.addUser({ id: "user-1", username: "dicoding" });
+    await ThreadsTableTestHelper.addThread({
+      id: "thread-1",
+      title: "thread title",
+      body: "thread body",
+      owner: "user-1",
+    });
+    await CommentsTableTestHelper.addComment({
+      id: "comment-1",
+      thread_id: "thread-1",
+      content: "comment content",
+      owner: "user-1",
+    });
+  });
+
+  afterEach(async () => {
+    await CommentLikesTableTestHelper.cleanTable();
+  });
+
+  afterAll(async () => {
+    await CommentLikesTableTestHelper.cleanTable();
+    await CommentsTableTestHelper.cleanTable();
+    await ThreadsTableTestHelper.cleanTable();
+    await UsersTableTestHelper.cleanTable();
+    await pool.end();
+  });
+
+  describe("constructor", () => {
+    it("should use default nanoid when idGenerator is not provided", async () => {
+      // Arrange
+      const repo = new CommentLikeRepositoryPostgres(pool); // No idGenerator passed
+
+      // Act
+      const result = await repo.addLike("comment-1", "user-1");
+
+      // Assert
+      expect(result.id).toMatch(/^like-/); // Should start with "like-"
+      expect(result.id.length).toBeGreaterThan(5); // "like-" + nanoid should be longer
+    });
+  });
+
+  describe("addLike function", () => {
+    it("should persist new like and return correct data", async () => {
+      // Arrange
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const result = await repo.addLike("comment-1", "user-1");
+
+      // Assert
+      expect(result).toEqual({
+        id: "like-123",
+      });
+
+      // Check DB
+      const likes = await CommentLikesTableTestHelper.findLikeById("like-123");
+      expect(likes).toHaveLength(1);
+      expect(likes[0].comment_id).toBe("comment-1");
+      expect(likes[0].owner).toBe("user-1");
+    });
+  });
+
+  describe("removeLike function", () => {
+    it("should remove like correctly", async () => {
+      // Arrange: add a like first
+      await CommentLikesTableTestHelper.addLike({
+        id: "like-123",
+        commentId: "comment-1",
+        owner: "user-1",
+      });
+
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+
+      // Act
+      await repo.removeLike("comment-1", "user-1");
+
+      // Assert
+      const likes = await CommentLikesTableTestHelper.findLikeById("like-123");
+      expect(likes).toHaveLength(0);
+    });
+
+    it("should throw error when removing non-existent like", async () => {
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+      await expect(repo.removeLike("comment-1", "user-1")).rejects.toThrow(
+        "COMMENT_LIKE_REPOSITORY.LIKE_NOT_FOUND",
+      );
+    });
+  });
+
+  describe("verifyLikeExistence function", () => {
+    it("should return true if like exists", async () => {
+      // Arrange: add a like first
+      await CommentLikesTableTestHelper.addLike({
+        id: "like-123",
+        commentId: "comment-1",
+        owner: "user-1",
+      });
+
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const exists = await repo.verifyLikeExistence("comment-1", "user-1");
+
+      // Assert
+      expect(exists).toBe(true);
+    });
+
+    it("should return false if like does not exist", async () => {
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const exists = await repo.verifyLikeExistence("comment-1", "user-1");
+
+      // Assert
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe("getLikeCountByCommentId function", () => {
+    it("should return correct like count", async () => {
+      // Arrange: add multiple likes
+      await UsersTableTestHelper.addUser({ id: "user-2", username: "johndoe" });
+      await CommentLikesTableTestHelper.addLike({
+        id: "like-1",
+        commentId: "comment-1",
+        owner: "user-1",
+      });
+      await CommentLikesTableTestHelper.addLike({
+        id: "like-2",
+        commentId: "comment-1",
+        owner: "user-2",
+      });
+
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const count = await repo.getLikeCountByCommentId("comment-1");
+
+      // Assert
+      expect(count).toBe(2);
+    });
+
+    it("should return 0 if no likes exist", async () => {
+      const repo = new CommentLikeRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const count = await repo.getLikeCountByCommentId("comment-1");
+
+      // Assert
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/src/Infrastructures/repository/_test/ReplyRepositoryPostgres.test.js
+++ b/src/Infrastructures/repository/_test/ReplyRepositoryPostgres.test.js
@@ -1,0 +1,229 @@
+const pool = require("../../database/postgres/pool");
+const ReplyRepositoryPostgres = require("../ReplyRepositoryPostgres");
+const NewReply = require("../../../Domains/replies/entities/NewReply");
+
+// Helper functions for setup/teardown
+const UsersTableTestHelper = require("../../../../tests/UsersTableTestHelper");
+const ThreadsTableTestHelper = require("../../../../tests/ThreadsTableTestHelper");
+const CommentsTableTestHelper = require("../../../../tests/CommentsTableTestHelper");
+const RepliesTableTestHelper = require("../../../../tests/RepliesTableTestHelper");
+
+describe("ReplyRepositoryPostgres", () => {
+  beforeAll(async () => {
+    // Insert a user, thread, and comment for foreign key constraints
+    await UsersTableTestHelper.addUser({ id: "user-1", username: "dicoding" });
+    await ThreadsTableTestHelper.addThread({
+      id: "thread-1",
+      title: "thread title",
+      body: "thread body",
+      owner: "user-1",
+    });
+    await CommentsTableTestHelper.addComment({
+      id: "comment-1",
+      thread_id: "thread-1",
+      content: "comment content",
+      owner: "user-1",
+    });
+  });
+
+  afterEach(async () => {
+    await RepliesTableTestHelper.cleanTable();
+  });
+
+  afterAll(async () => {
+    await RepliesTableTestHelper.cleanTable();
+    await CommentsTableTestHelper.cleanTable();
+    await ThreadsTableTestHelper.cleanTable();
+    await UsersTableTestHelper.cleanTable();
+    await pool.end();
+  });
+
+  describe("constructor", () => {
+    it("should use default nanoid when idGenerator is not provided", async () => {
+      // Arrange
+      const repo = new ReplyRepositoryPostgres(pool); // No idGenerator passed
+      const newReply = new NewReply({ content: "test reply" });
+
+      // Act
+      const result = await repo.addReply(newReply, "comment-1", "user-1");
+
+      // Assert
+      expect(result.id).toMatch(/^reply-/); // Should start with "reply-"
+      expect(result.id.length).toBeGreaterThan(6); // "reply-" + nanoid should be longer
+      expect(result.content).toBe("test reply");
+      expect(result.owner).toBe("user-1");
+    });
+  });
+
+  describe("addReply function", () => {
+    it("should persist new reply and return correct data", async () => {
+      // Arrange
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+      const newReply = new NewReply({ content: "test reply" });
+
+      // Act
+      const result = await repo.addReply(newReply, "comment-1", "user-1");
+
+      // Assert
+      expect(result).toEqual({
+        id: "reply-123",
+        content: "test reply",
+        owner: "user-1",
+      });
+
+      // Check DB
+      const replies = await RepliesTableTestHelper.findReplyById("reply-123");
+      expect(replies).toHaveLength(1);
+      expect(replies[0].content).toBe("test reply");
+      expect(replies[0].owner).toBe("user-1");
+      expect(replies[0].is_delete).toBe(false);
+    });
+  });
+
+  describe("deleteReply function", () => {
+    it("should soft delete reply", async () => {
+      // Arrange: add a reply first
+      await RepliesTableTestHelper.addReply({
+        id: "reply-123",
+        content: "to be deleted",
+        commentId: "comment-1",
+        owner: "user-1",
+        isDelete: false,
+      });
+
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+      await repo.deleteReply("reply-123");
+
+      // Check DB for is_delete = true
+      const replies = await RepliesTableTestHelper.findReplyById("reply-123");
+      expect(replies[0].is_delete).toBe(true);
+    });
+
+    it("should throw error when deleting non-existent reply", async () => {
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+      await expect(repo.deleteReply("reply-not-exist")).rejects.toThrow(
+        "REPLY_REPOSITORY.REPLY_NOT_FOUND"
+      );
+    });
+  });
+
+  describe("verifyReplyOwner function", () => {
+    it("should verify reply owner correctly", async () => {
+      // Arrange: add a reply
+      await RepliesTableTestHelper.addReply({
+        id: "reply-123",
+        content: "test",
+        commentId: "comment-1",
+        owner: "user-1",
+        isDelete: false,
+      });
+
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+
+      // Should not throw any error when owner is correct
+      await expect(
+        repo.verifyReplyOwner("reply-123", "user-1")
+      ).resolves.not.toThrow("REPLY_REPOSITORY.NOT_THE_OWNER");
+
+      // Should throw error when owner is different
+      await expect(
+        repo.verifyReplyOwner("reply-123", "user-2")
+      ).rejects.toThrow("REPLY_REPOSITORY.NOT_THE_OWNER");
+    });
+
+    it("should throw error when verifying owner of non-existent reply", async () => {
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+      await expect(
+        repo.verifyReplyOwner("reply-not-exist", "user-1")
+      ).rejects.toThrow("REPLY_REPOSITORY.REPLY_NOT_FOUND");
+    });
+  });
+
+  describe("verifyReplyExists function", () => {
+    it("should not throw error when reply exists", async () => {
+      // Arrange: add a reply
+      await RepliesTableTestHelper.addReply({
+        id: "reply-123",
+        content: "test",
+        commentId: "comment-1",
+        owner: "user-1",
+      });
+
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+
+      // Act & Assert
+      await expect(repo.verifyReplyExists("reply-123")).resolves.not.toThrow();
+    });
+
+    it("should throw error when reply does not exist", async () => {
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+      await expect(repo.verifyReplyExists("reply-not-exist")).rejects.toThrow(
+        "REPLY_REPOSITORY.REPLY_NOT_FOUND"
+      );
+    });
+  });
+
+  describe("getRepliesByCommentId function", () => {
+    it("should return replies for a comment, including deleted ones", async () => {
+      // Arrange
+      const replyDate1 = new Date(Date.UTC(2023, 0, 1, 0, 0, 0));
+      const replyDate2 = new Date(Date.UTC(2023, 0, 1, 1, 0, 0));
+
+      await RepliesTableTestHelper.addReply({
+        id: "reply-1",
+        commentId: "comment-1",
+        content: "A reply",
+        date: replyDate1.toISOString(),
+        owner: "user-1",
+        isDelete: false,
+      });
+      await RepliesTableTestHelper.addReply({
+        id: "reply-2",
+        commentId: "comment-1",
+        content: "Deleted reply",
+        date: replyDate2.toISOString(),
+        owner: "user-1",
+        isDelete: true,
+      });
+
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const replies = await repo.getRepliesByCommentId("comment-1");
+
+      // Assert
+      expect(replies).toHaveLength(2);
+
+      expect(replies[0]).toMatchObject({
+        id: "reply-1",
+        username: "dicoding",
+        content: "A reply",
+        is_delete: false,
+      });
+      expect(new Date(replies[0].date).toISOString()).toEqual(
+        replyDate1.toISOString()
+      );
+
+      expect(replies[1]).toMatchObject({
+        id: "reply-2",
+        username: "dicoding",
+        content: "Deleted reply",
+        is_delete: true,
+      });
+      expect(new Date(replies[1].date).toISOString()).toEqual(
+        replyDate2.toISOString()
+      );
+    });
+
+    it("should return empty array when comment has no replies", async () => {
+      const repo = new ReplyRepositoryPostgres(pool, () => "123");
+
+      // Act
+      const replies = await repo.getRepliesByCommentId("comment-1");
+
+      // Assert
+      expect(replies).toHaveLength(0);
+      expect(replies).toEqual([]);
+    });
+  });
+});

--- a/src/Interfaces/http/api/comments/_test/handler.test.js
+++ b/src/Interfaces/http/api/comments/_test/handler.test.js
@@ -13,6 +13,7 @@ describe('CommentsHandler', () => {
       expect(handler._container).toBe(mockContainer);
       expect(typeof handler.postCommentHandler).toBe('function');
       expect(typeof handler.deleteCommentHandler).toBe('function');
+      expect(typeof handler.likeCommentHandler).toBe('function');
     });
   });
 
@@ -207,6 +208,79 @@ describe('CommentsHandler', () => {
         'thread-123',
         'comment-123',
         'user-456'
+      );
+    });
+  });
+
+  describe('likeCommentHandler', () => {
+    it('should return success status', async () => {
+      // Arrange
+      const mockLikeCommentUseCase = {
+        execute: jest.fn().mockResolvedValue(),
+      };
+      const mockContainer = {
+        getInstance: jest.fn().mockReturnValue(mockLikeCommentUseCase),
+      };
+
+      const request = {
+        auth: {
+          credentials: { id: 'user-123' },
+        },
+        params: { 
+          threadId: 'thread-123',
+          commentId: 'comment-123' 
+        },
+      };
+
+      const h = {};
+
+      const handler = new CommentsHandler(mockContainer);
+
+      // Action
+      const response = await handler.likeCommentHandler(request, h);
+
+      // Assert
+      expect(mockContainer.getInstance).toBeCalledWith('LikeCommentUseCase');
+      expect(mockLikeCommentUseCase.execute).toBeCalledWith(
+        'thread-123',
+        'comment-123',
+        'user-123'
+      );
+      expect(response).toEqual({
+        status: 'success',
+      });
+    });
+
+    it('should handle error when use case throws error', async () => {
+      // Arrange
+      const mockLikeCommentUseCase = {
+        execute: jest.fn().mockRejectedValue(new Error('Thread not found')),
+      };
+      const mockContainer = {
+        getInstance: jest.fn().mockReturnValue(mockLikeCommentUseCase),
+      };
+
+      const request = {
+        auth: {
+          credentials: { id: 'user-123' },
+        },
+        params: { 
+          threadId: 'thread-123',
+          commentId: 'comment-123' 
+        },
+      };
+
+      const h = {};
+
+      const handler = new CommentsHandler(mockContainer);
+
+      // Action & Assert
+      await expect(handler.likeCommentHandler(request, h)).rejects.toThrow('Thread not found');
+      expect(mockContainer.getInstance).toBeCalledWith('LikeCommentUseCase');
+      expect(mockLikeCommentUseCase.execute).toBeCalledWith(
+        'thread-123',
+        'comment-123',
+        'user-123'
       );
     });
   });

--- a/src/Interfaces/http/api/comments/handler.js
+++ b/src/Interfaces/http/api/comments/handler.js
@@ -4,6 +4,7 @@ class CommentsHandler {
 
     this.postCommentHandler = this.postCommentHandler.bind(this);
     this.deleteCommentHandler = this.deleteCommentHandler.bind(this);
+    this.likeCommentHandler = this.likeCommentHandler.bind(this);
   }
 
   async postCommentHandler(request, h) {
@@ -33,6 +34,17 @@ class CommentsHandler {
     const { id: owner } = request.auth.credentials;
     const { threadId, commentId } = request.params;
     await deleteCommentUseCase.execute(threadId, commentId, owner);
+
+    return {
+      status: "success",
+    };
+  }
+
+  async likeCommentHandler(request, h) {
+    const likeCommentUseCase = this._container.getInstance("LikeCommentUseCase");
+    const { id: owner } = request.auth.credentials;
+    const { threadId, commentId } = request.params;
+    await likeCommentUseCase.execute(threadId, commentId, owner);
 
     return {
       status: "success",

--- a/src/Interfaces/http/api/comments/routes.js
+++ b/src/Interfaces/http/api/comments/routes.js
@@ -15,6 +15,14 @@ const routes = (handler) => [
       auth: "forumapi_jwt",
     },
   },
+  {
+    method: "PUT",
+    path: "/threads/{threadId}/comments/{commentId}/likes",
+    handler: handler.likeCommentHandler,
+    options: {
+      auth: "forumapi_jwt",
+    },
+  },
 ];
 
 module.exports = routes;

--- a/src/Interfaces/http/api/replies/handler.js
+++ b/src/Interfaces/http/api/replies/handler.js
@@ -1,0 +1,42 @@
+class RepliesHandler {
+  constructor(container) {
+    this._container = container;
+
+    this.postReplyHandler = this.postReplyHandler.bind(this);
+    this.deleteReplyHandler = this.deleteReplyHandler.bind(this);
+  }
+
+  async postReplyHandler(request, h) {
+    const addReplyUseCase = this._container.getInstance('AddReplyUseCase');
+    const { id: owner } = request.auth.credentials;
+    const { threadId, commentId } = request.params;
+    const addedReply = await addReplyUseCase.execute(
+      request.payload,
+      commentId,
+      threadId,
+      owner
+    );
+
+    const response = h.response({
+      status: 'success',
+      data: {
+        addedReply,
+      },
+    });
+    response.code(201);
+    return response;
+  }
+
+  async deleteReplyHandler(request, h) {
+    const deleteReplyUseCase = this._container.getInstance('DeleteReplyUseCase');
+    const { id: owner } = request.auth.credentials;
+    const { threadId, commentId, replyId } = request.params;
+    await deleteReplyUseCase.execute(threadId, commentId, replyId, owner);
+
+    return {
+      status: 'success',
+    };
+  }
+}
+
+module.exports = RepliesHandler;

--- a/src/Interfaces/http/api/replies/index.js
+++ b/src/Interfaces/http/api/replies/index.js
@@ -1,0 +1,10 @@
+const RepliesHandler = require('./handler');
+const routes = require('./routes');
+
+module.exports = {
+  name: 'replies',
+  register: async (server, { container }) => {
+    const repliesHandler = new RepliesHandler(container);
+    server.route(routes(repliesHandler));
+  },
+};

--- a/src/Interfaces/http/api/replies/routes.js
+++ b/src/Interfaces/http/api/replies/routes.js
@@ -1,0 +1,20 @@
+const routes = (handler) => [
+  {
+    method: 'POST',
+    path: '/threads/{threadId}/comments/{commentId}/replies',
+    handler: handler.postReplyHandler,
+    options: {
+      auth: 'forumapi_jwt',
+    },
+  },
+  {
+    method: 'DELETE',
+    path: '/threads/{threadId}/comments/{commentId}/replies/{replyId}',
+    handler: handler.deleteReplyHandler,
+    options: {
+      auth: 'forumapi_jwt',
+    },
+  },
+];
+
+module.exports = routes;

--- a/tests/CommentLikesTableTestHelper.js
+++ b/tests/CommentLikesTableTestHelper.js
@@ -1,0 +1,54 @@
+/* istanbul ignore file */
+const pool = require("../src/Infrastructures/database/postgres/pool");
+
+const CommentLikesTableTestHelper = {
+  async addLike({
+    id = "like-123",
+    commentId = "comment-123",
+    owner = "user-123",
+    date = new Date(),
+  }) {
+    const query = {
+      text: "INSERT INTO comment_likes VALUES($1, $2, $3, $4)",
+      values: [id, commentId, owner, date],
+    };
+
+    await pool.query(query);
+  },
+
+  async findLikeById(id) {
+    const query = {
+      text: "SELECT * FROM comment_likes WHERE id = $1",
+      values: [id],
+    };
+
+    const result = await pool.query(query);
+    return result.rows;
+  },
+
+  async findLikeByCommentAndOwner(commentId, owner) {
+    const query = {
+      text: "SELECT * FROM comment_likes WHERE comment_id = $1 AND owner = $2",
+      values: [commentId, owner],
+    };
+
+    const result = await pool.query(query);
+    return result.rows;
+  },
+
+  async getLikeCountByCommentId(commentId) {
+    const query = {
+      text: "SELECT COUNT(*) as count FROM comment_likes WHERE comment_id = $1",
+      values: [commentId],
+    };
+
+    const result = await pool.query(query);
+    return parseInt(result.rows[0].count, 10);
+  },
+
+  async cleanTable() {
+    await pool.query("DELETE FROM comment_likes WHERE 1=1");
+  },
+};
+
+module.exports = CommentLikesTableTestHelper;

--- a/tests/RepliesTableTestHelper.js
+++ b/tests/RepliesTableTestHelper.js
@@ -1,0 +1,36 @@
+/* istanbul ignore file */
+const pool = require("../src/Infrastructures/database/postgres/pool");
+
+const RepliesTableTestHelper = {
+  async addReply({
+    id = "reply-123",
+    content = "sebuah balasan",
+    commentId = "comment-123",
+    owner = "user-123",
+    date = new Date().toISOString(),
+    isDelete = false,
+  }) {
+    const query = {
+      text: "INSERT INTO replies (id, content, comment_id, owner, date, is_delete) VALUES($1, $2, $3, $4, $5, $6)",
+      values: [id, content, commentId, owner, date, isDelete],
+    };
+
+    await pool.query(query);
+  },
+
+  async findReplyById(id) {
+    const query = {
+      text: "SELECT * FROM replies WHERE id = $1",
+      values: [id],
+    };
+
+    const result = await pool.query(query);
+    return result.rows;
+  },
+
+  async cleanTable() {
+    await pool.query("DELETE FROM replies WHERE 1=1");
+  },
+};
+
+module.exports = RepliesTableTestHelper;


### PR DESCRIPTION
- Added CommentLikeRepositoryPostgres for managing comment likes, including methods for adding, removing, verifying existence, and counting likes.
- Introduced ReplyRepositoryPostgres for handling replies, with functionalities for adding, deleting, verifying ownership, and retrieving replies by comment ID.
- Created comprehensive test suites for both CommentLikeRepositoryPostgres and ReplyRepositoryPostgres to ensure functionality and reliability.
- Developed HTTP handlers and routes for replies, enabling the posting and deletion of replies via API endpoints.
- Added helper functions for managing test data in CommentLikes and Replies tables.